### PR TITLE
Ensure that values in $in query are unique

### DIFF
--- a/lib/mio-mongo.js
+++ b/lib/mio-mongo.js
@@ -347,24 +347,24 @@ exports.findOne = function (query, done) {
 
             if (relType === 'belongsTo') {
               rquery.where(RelatedResource.primaryKey, {
-                $in: resource[relationName].map(function (through) {
+                $in: unique(resource[relationName].map(function (through) {
                   intermediaries[through[foreignKey]] = through;
                   return through[foreignKey];
-                })
+                }))
               });
             } else if (relType === 'hasOne') {
               rquery.where(foreignKey, {
-                $in: resource[relationName].map(function (through) {
+                $in: unique(resource[relationName].map(function (through) {
                   intermediaries[through.primary] = through;
                   return through.primary;
-                })
+                }))
               });
             } else {
               rquery.where(foreignKey, {
-                $in: resource[relationName].map(function (through) {
+                $in: unique(resource[relationName].map(function (through) {
                   intermediaries[resource.primary] = through;
                   return resource.primary;
-                })
+                }))
               });
             }
 
@@ -1331,4 +1331,19 @@ function factory (fn, ctx) {
   }
 
   return fn;
+}
+
+function unique(array) {
+  var set = [];
+  function contains (haystack, needle) {
+    return !!haystack.filter(function(item) {
+      return item === needle;
+    }).length;
+  }
+  array.forEach(function (value) {
+    if (!contains(set, value)) {
+      set.push(value);
+    }
+  });
+  return set;
 }


### PR DESCRIPTION
There are instances when retrieving related resources results in an $in query with duplicate values. This is fixed by ensuring the values are unique.