### PR TITLE
Emit event after plugin has initialized

### DIFF
--- a/lib/mio-mongo.js
+++ b/lib/mio-mongo.js
@@ -115,6 +115,9 @@ module.exports = function createMioMongoPlugin(settings) {
       .hook('collection:patch', exports.updateMany)
       .hook('collection:post', exports.createMany)
       .hook('collection:delete', exports.destroyMany);
+      
+    // emit event signaling that plugin initialization has finished
+    Resource.emit('mongo:initialize');
   };
 };
 


### PR DESCRIPTION
It would be nice to be able to listen to this event to do things after initialization such as attach hooks.